### PR TITLE
Remove --version flag (gh cli provides version info)

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -14,8 +14,6 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
-          # Fetch full history and tags so the Go toolchain can stamp the
-          # release tag into the binary's build info (act --version).
           fetch-depth: 0
       - uses: cli/gh-extension-precompile@76961aa3bd1123d0a6fd42d0a41aca0696937c39 # v2.2.0
         with:

--- a/README.md
+++ b/README.md
@@ -136,5 +136,4 @@ COMMANDS:
 GLOBAL OPTIONS:
    --debug        Print debug logs
    --help, -h     show help
-   --version, -v  print the version
 ```

--- a/main.go
+++ b/main.go
@@ -6,65 +6,11 @@ import (
 	"log/slog"
 	"os"
 	"os/signal"
-	"runtime/debug"
-	"strings"
 	"syscall"
 
 	"github.com/urfave/cli/v3"
 	"github.com/wayneashleyberry/gh-act/pkg/cmd"
 )
-
-// shortSHALen is how many characters of a commit SHA to display.
-const shortSHALen = 7
-
-// buildVersion derives the version shown by `act --version` from the build
-// info stamped by the Go toolchain. For a precompiled release (a clean build
-// at a git tag) it returns "<tag> (<short-sha>)". Otherwise it falls back to
-// the short commit SHA (with a "-dirty" suffix for uncommitted changes), or
-// "dev" when no build info is available.
-func buildVersion() string {
-	info, ok := debug.ReadBuildInfo()
-	if !ok {
-		return "dev"
-	}
-
-	var revision, dirty string
-
-	for _, setting := range info.Settings {
-		switch setting.Key {
-		case "vcs.revision":
-			revision = setting.Value
-		case "vcs.modified":
-			if setting.Value == "true" {
-				dirty = "-dirty"
-			}
-		}
-	}
-
-	short := revision
-	if len(short) > shortSHALen {
-		short = short[:shortSHALen]
-	}
-
-	// A clean tagged build (the release case) stamps the tag into
-	// Main.Version. Pseudo-versions embed the commit SHA, so exclude those.
-	tag := info.Main.Version
-	isPseudo := short != "" && strings.Contains(tag, short)
-
-	if tag != "" && tag != "(devel)" && !isPseudo {
-		if short == "" {
-			return tag
-		}
-
-		return fmt.Sprintf("%s (%s)", tag, short)
-	}
-
-	if short == "" {
-		return "dev"
-	}
-
-	return short + dirty
-}
 
 func setDefaultLogger(level slog.Leveler) {
 	handler := slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{
@@ -98,9 +44,8 @@ func run(ctx context.Context) error {
 	}
 
 	command := &cli.Command{
-		Name:    "act",
-		Usage:   "Update, manage and pin your GitHub Actions",
-		Version: buildVersion(),
+		Name:  "act",
+		Usage: "Update, manage and pin your GitHub Actions",
 		Flags: []cli.Flag{
 			&cli.BoolFlag{
 				Name:  "debug",


### PR DESCRIPTION
The GitHub CLI already provides version information for extensions, so the `--version` flag in this extension is redundant.\n\n### Changes\n\n- **`main.go`**: Remove `buildVersion()` function, the `shortSHALen` constant, and the `Version` field on the root command. Also removes the now-unused `runtime/debug` and `strings` imports.\n- **`README.md`**: Remove `--version, -v` from the global options section in the help output example.\n- **`.github/workflows/release.yaml`**: Remove the comment referencing `act --version` from the `fetch-depth: 0` checkout step (the setting is kept as it is still needed for a full git history during release builds).