### PR TITLE
embedded yaml in markdown support

### DIFF
--- a/main.go
+++ b/main.go
@@ -43,6 +43,15 @@ func run(ctx context.Context) error {
 		Usage: "Print the changes that would be made without writing any files",
 	}
 
+	noMDFlag := &cli.BoolFlag{
+		Name:  "no-md",
+		Usage: "Skip scanning fenced YAML code blocks in markdown files",
+	}
+
+	collectOpts := func(c *cli.Command) cmd.CollectOptions {
+		return cmd.CollectOptions{IncludeMarkdown: !c.Bool("no-md")}
+	}
+
 	command := &cli.Command{
 		Name:  "act",
 		Usage: "Update, manage and pin your GitHub Actions",
@@ -63,8 +72,9 @@ func run(ctx context.Context) error {
 			{
 				Name:  "ls",
 				Usage: "List used actions",
-				Action: func(_ context.Context, _ *cli.Command) error {
-					return cmd.ListActions()
+				Flags: []cli.Flag{noMDFlag},
+				Action: func(_ context.Context, c *cli.Command) error {
+					return cmd.ListActions(collectOpts(c))
 				},
 			},
 			{
@@ -75,9 +85,10 @@ func run(ctx context.Context) error {
 						Name:  "exit-code",
 						Usage: "Exit with a non-zero status when outdated actions are found",
 					},
+					noMDFlag,
 				},
 				Action: func(ctx context.Context, c *cli.Command) error {
-					found, err := cmd.ListOutdatedActions(ctx)
+					found, err := cmd.ListOutdatedActions(ctx, collectOpts(c))
 					if err != nil {
 						return err
 					}
@@ -98,17 +109,18 @@ func run(ctx context.Context) error {
 						Usage: "Pin actions after updating them (required for branch references like @main)",
 					},
 					dryRunFlag,
+					noMDFlag,
 				},
 				Action: func(ctx context.Context, c *cli.Command) error {
-					return cmd.UpdateActions(ctx, c.Bool("pin"), c.Bool("dry-run"))
+					return cmd.UpdateActions(ctx, c.Bool("pin"), c.Bool("dry-run"), collectOpts(c))
 				},
 			},
 			{
 				Name:  "pin",
 				Usage: "Pin used actions",
-				Flags: []cli.Flag{dryRunFlag},
+				Flags: []cli.Flag{dryRunFlag, noMDFlag},
 				Action: func(ctx context.Context, c *cli.Command) error {
-					return cmd.PinActions(ctx, c.Bool("dry-run"))
+					return cmd.PinActions(ctx, c.Bool("dry-run"), collectOpts(c))
 				},
 			},
 		},

--- a/pkg/cmd/list.go
+++ b/pkg/cmd/list.go
@@ -4,8 +4,8 @@ import "fmt"
 
 // ListActions prints every external action reference found in the repository's
 // workflow and composite-action files. It performs no network calls.
-func ListActions() error {
-	actions, err := findActions()
+func ListActions(opts CollectOptions) error {
+	actions, err := findActions(opts)
 	if err != nil {
 		return fmt.Errorf("find actions: %w", err)
 	}
@@ -24,8 +24,8 @@ func ListActions() error {
 
 // findActions discovers and parses every action reference across all workflow
 // and composite-action files.
-func findActions() ([]Action, error) {
-	_, refs, err := collectActionRefs()
+func findActions(opts CollectOptions) ([]Action, error) {
+	_, refs, err := collectActionRefs(opts)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/cmd/markdown.go
+++ b/pkg/cmd/markdown.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"io/fs"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"strings"
@@ -47,21 +48,23 @@ func extractYAMLBlocks(data []byte) []yamlBlock {
 			if lower == "```yaml" {
 				inBlock = true
 				blockLines = nil
-				blockStart = i + 2 // +1 for 0→1-indexed, +1 to skip the fence line itself
+				// i is 0-indexed; +1 converts to 1-indexed, +1 skips past the
+				// fence line itself to land on the first content line.
+				blockStart = i + 2
 			}
 
 			continue
 		}
 
-		if bytes.HasPrefix(trimmed, []byte("```")) {
-			// Closing fence — collect the block.
-			strs := make([]string, len(blockLines))
-			for j, l := range blockLines {
-				strs[j] = string(l)
-			}
-
+		// A closing fence is exactly ``` with no info string. Checking for an
+		// exact match (rather than HasPrefix) prevents a line like ```go inside
+		// a YAML block from accidentally closing it.
+		if bytes.Equal(trimmed, []byte("```")) {
+			// \r has already been stripped from each line above, so joining
+			// with \n gives the YAML parser clean LF-only input regardless of
+			// the original file's line endings.
 			blocks = append(blocks, yamlBlock{
-				content:    []byte(strings.Join(strs, "\n")),
+				content:    bytes.Join(blockLines, []byte("\n")),
 				lineOffset: blockStart,
 			})
 
@@ -125,11 +128,21 @@ func findActionRefsInMarkdownFile(filePath string) ([]Action, error) {
 	for _, block := range blocks {
 		refs, err := parseActionRefs(block.content, filePath)
 		if err != nil {
-			// A malformed YAML block in a README shouldn't abort the whole run.
+			// A malformed YAML block (e.g. an illustrative code sample showing
+			// invalid syntax) should not abort the whole run.
+			slog.Debug("skipping malformed YAML block in markdown file",
+				slog.String("file.path", filePath),
+				slog.String("error.message", err.Error()),
+			)
+
 			continue
 		}
 
 		for i := range refs {
+			// yaml.Unmarshal returns 1-indexed line numbers relative to the
+			// YAML fragment. Adding lineOffset-1 converts them to absolute line
+			// numbers within the markdown file (lineOffset is already the
+			// 1-indexed first content line, so -1 avoids double-counting).
 			refs[i].Node.Line += block.lineOffset - 1
 		}
 

--- a/pkg/cmd/markdown.go
+++ b/pkg/cmd/markdown.go
@@ -1,0 +1,140 @@
+package cmd
+
+import (
+	"bytes"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// isMarkdownFile reports whether name has a markdown file extension.
+func isMarkdownFile(name string) bool {
+	ext := strings.ToLower(filepath.Ext(name))
+
+	return ext == ".md" || ext == ".markdown"
+}
+
+// yamlBlock is a YAML code fence extracted from a markdown file. lineOffset is
+// the 1-based line number in the original markdown file of the first line of
+// content inside the fence (i.e. the line immediately after the opening ```).
+type yamlBlock struct {
+	content    []byte
+	lineOffset int
+}
+
+// extractYAMLBlocks scans markdown source line-by-line and returns every fenced
+// YAML code block. Opening fences are ```yaml (case-insensitive), with optional
+// leading whitespace. Unclosed fences are silently discarded.
+func extractYAMLBlocks(data []byte) []yamlBlock {
+	lines := bytes.Split(data, []byte("\n"))
+
+	var blocks []yamlBlock
+
+	inBlock := false
+
+	var blockLines [][]byte
+
+	blockStart := 0
+
+	for i, raw := range lines {
+		line := bytes.TrimRight(raw, "\r") // strip \r from CRLF files
+		trimmed := bytes.TrimLeft(line, " \t")
+		lower := strings.ToLower(string(trimmed))
+
+		if !inBlock {
+			if lower == "```yaml" {
+				inBlock = true
+				blockLines = nil
+				blockStart = i + 2 // +1 for 0→1-indexed, +1 to skip the fence line itself
+			}
+
+			continue
+		}
+
+		if bytes.HasPrefix(trimmed, []byte("```")) {
+			// Closing fence — collect the block.
+			strs := make([]string, len(blockLines))
+			for j, l := range blockLines {
+				strs[j] = string(l)
+			}
+
+			blocks = append(blocks, yamlBlock{
+				content:    []byte(strings.Join(strs, "\n")),
+				lineOffset: blockStart,
+			})
+
+			inBlock = false
+			blockLines = nil
+
+			continue
+		}
+
+		blockLines = append(blockLines, line)
+	}
+
+	// Unclosed fences are discarded.
+	return blocks
+}
+
+// findMarkdownFiles returns every markdown file in the repository. The .git,
+// node_modules, and vendor directories are skipped.
+func findMarkdownFiles() ([]string, error) {
+	var files []string
+
+	if err := filepath.WalkDir(".", func(path string, entry fs.DirEntry, err error) error {
+		if err != nil {
+			return nil //nolint:nilerr // tolerate unreadable entries
+		}
+
+		if entry.IsDir() {
+			if skippedWalkDirs[entry.Name()] {
+				return filepath.SkipDir
+			}
+
+			return nil
+		}
+
+		if isMarkdownFile(entry.Name()) {
+			files = append(files, filepath.Clean(path))
+		}
+
+		return nil
+	}); err != nil {
+		return nil, fmt.Errorf("scan for markdown files: %w", err)
+	}
+
+	return files, nil
+}
+
+// findActionRefsInMarkdownFile parses every fenced YAML block in a markdown
+// file and returns the action references found within them. Each Action's
+// Node.Line is adjusted to be the correct 1-based line number within the
+// markdown file rather than within the YAML fragment.
+func findActionRefsInMarkdownFile(filePath string) ([]Action, error) {
+	data, err := os.ReadFile(filePath)
+	if err != nil {
+		return nil, fmt.Errorf("read file %q: %w", filePath, err)
+	}
+
+	blocks := extractYAMLBlocks(data)
+
+	var actions []Action
+
+	for _, block := range blocks {
+		refs, err := parseActionRefs(block.content, filePath)
+		if err != nil {
+			// A malformed YAML block in a README shouldn't abort the whole run.
+			continue
+		}
+
+		for i := range refs {
+			refs[i].Node.Line += block.lineOffset - 1
+		}
+
+		actions = append(actions, refs...)
+	}
+
+	return actions, nil
+}

--- a/pkg/cmd/markdown_test.go
+++ b/pkg/cmd/markdown_test.go
@@ -32,22 +32,22 @@ func TestIsMarkdownFile(t *testing.T) {
 
 func TestExtractYAMLBlocks(t *testing.T) {
 	tests := []struct {
-		name            string
-		markdown        string
-		wantOffsets     []int
-		wantContents    []string
-		wantBlockCount  int
+		name           string
+		markdown       string
+		wantOffsets    []int
+		wantContents   []string
+		wantBlockCount int
 	}{
 		{
-			name: "single yaml block",
-			markdown: "# Title\n\nSome text.\n\n```yaml\njobs:\n  build:\n    steps:\n      - uses: actions/checkout@v4\n```\n",
+			name:           "single yaml block",
+			markdown:       "# Title\n\nSome text.\n\n```yaml\njobs:\n  build:\n    steps:\n      - uses: actions/checkout@v4\n```\n",
 			wantBlockCount: 1,
 			wantOffsets:    []int{6},
 			wantContents:   []string{"jobs:\n  build:\n    steps:\n      - uses: actions/checkout@v4"},
 		},
 		{
-			name: "multiple blocks",
-			markdown: "```yaml\nfirst: block\n```\n\nSome prose.\n\n```yaml\nsecond: block\n```\n",
+			name:           "multiple blocks",
+			markdown:       "```yaml\nfirst: block\n```\n\nSome prose.\n\n```yaml\nsecond: block\n```\n",
 			wantBlockCount: 2,
 			wantOffsets:    []int{2, 8},
 			wantContents:   []string{"first: block", "second: block"},
@@ -68,22 +68,22 @@ func TestExtractYAMLBlocks(t *testing.T) {
 			wantBlockCount: 0,
 		},
 		{
-			name: "case insensitive fence",
-			markdown: "```YAML\njobs: {}\n```\n",
+			name:           "case insensitive fence",
+			markdown:       "```YAML\njobs: {}\n```\n",
 			wantBlockCount: 1,
 			wantOffsets:    []int{2},
 			wantContents:   []string{"jobs: {}"},
 		},
 		{
-			name: "fence with leading whitespace",
-			markdown: "  ```yaml\n  jobs: {}\n  ```\n",
+			name:           "fence with leading whitespace",
+			markdown:       "  ```yaml\n  jobs: {}\n  ```\n",
 			wantBlockCount: 1,
 			wantOffsets:    []int{2},
 			wantContents:   []string{"  jobs: {}"},
 		},
 		{
-			name: "empty yaml block",
-			markdown: "```yaml\n```\n",
+			name:           "empty yaml block",
+			markdown:       "```yaml\n```\n",
 			wantBlockCount: 1,
 			wantOffsets:    []int{2},
 			wantContents:   []string{""},

--- a/pkg/cmd/markdown_test.go
+++ b/pkg/cmd/markdown_test.go
@@ -116,10 +116,18 @@ func TestExtractYAMLBlocksCRLF(t *testing.T) {
 func TestFindActionRefsInMarkdownFile(t *testing.T) {
 	dir := t.TempDir()
 
-	// The uses: line is on markdown file line 7 (fence opens line 5, content
-	// starts line 6, uses: is the second content line → line 7).
+	// Markdown line layout (1-indexed):
+	//  1: # README
+	//  2: (blank)
+	//  3: Some docs.
+	//  4: (blank)
+	//  5: ```yaml          <- fence opens; blockStart = 5+2 = 7... wait, i=4 (0-indexed) → blockStart = 4+2 = 6
+	//  6: jobs:            <- YAML line 1
+	//  7:   build:         <- YAML line 2
+	//  8:     steps:       <- YAML line 3
+	//  9:       - uses:    <- YAML line 4  →  file line = blockStart + YAML line - 1 = 6 + 4 - 1 = 9
+	// 10: ```
 	markdown := "# README\n\nSome docs.\n\n```yaml\njobs:\n  build:\n    steps:\n      - uses: actions/checkout@v4\n```\n"
-	// Line numbers:        1          2              3       4           5       6       7       8       9                                10
 
 	path := filepath.Join(dir, "README.md")
 	require.NoError(t, os.WriteFile(path, []byte(markdown), 0o600))
@@ -128,13 +136,30 @@ func TestFindActionRefsInMarkdownFile(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, actions, 1)
 	require.Equal(t, "actions/checkout@v4", actions[0].Node.Value)
-	// Fence opens on line 5 → content starts line 6. uses: is YAML line 4 → file line 6+4-1 = 9.
 	require.Equal(t, 9, actions[0].Node.Line)
 }
 
 func TestFindActionRefsInMarkdownFileMultipleBlocks(t *testing.T) {
 	dir := t.TempDir()
 
+	// Markdown line layout (1-indexed):
+	//  1: # Title
+	//  2: (blank)
+	//  3: ```yaml        ← i=2 (0-indexed) → blockStart=4
+	//  4: jobs:
+	//  5:   a:
+	//  6:     steps:
+	//  7:       - uses: actions/checkout@v4   ← YAML line 4 → file line 4+4-1 = 7
+	//  8: ```
+	//  9: (blank)
+	// 10: More prose.
+	// 11: (blank)
+	// 12: ```yaml        ← i=11 (0-indexed) → blockStart=13
+	// 13: jobs:
+	// 14:   b:
+	// 15:     steps:
+	// 16:       - uses: actions/setup-go@v5   ← YAML line 4 → file line 13+4-1 = 16
+	// 17: ```
 	markdown := "# Title\n\n```yaml\njobs:\n  a:\n    steps:\n      - uses: actions/checkout@v4\n```\n\nMore prose.\n\n```yaml\njobs:\n  b:\n    steps:\n      - uses: actions/setup-go@v5\n```\n"
 
 	path := filepath.Join(dir, "README.md")
@@ -144,9 +169,11 @@ func TestFindActionRefsInMarkdownFileMultipleBlocks(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, actions, 2)
 
-	values := []string{actions[0].Node.Value, actions[1].Node.Value}
-	require.Contains(t, values, "actions/checkout@v4")
-	require.Contains(t, values, "actions/setup-go@v5")
+	require.Equal(t, "actions/checkout@v4", actions[0].Node.Value)
+	require.Equal(t, 7, actions[0].Node.Line)
+
+	require.Equal(t, "actions/setup-go@v5", actions[1].Node.Value)
+	require.Equal(t, 16, actions[1].Node.Line)
 }
 
 func TestFindActionRefsInMarkdownFileNoBlocks(t *testing.T) {

--- a/pkg/cmd/markdown_test.go
+++ b/pkg/cmd/markdown_test.go
@@ -1,0 +1,202 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestIsMarkdownFile(t *testing.T) {
+	tests := []struct {
+		name string
+		want bool
+	}{
+		{name: "README.md", want: true},
+		{name: "readme.MD", want: true},
+		{name: "CONTRIBUTING.markdown", want: true},
+		{name: "docs.MARKDOWN", want: true},
+		{name: "workflow.yml", want: false},
+		{name: "action.yaml", want: false},
+		{name: "noextension", want: false},
+		{name: ".md", want: true}, // dotfile with .md extension
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, isMarkdownFile(tt.name))
+		})
+	}
+}
+
+func TestExtractYAMLBlocks(t *testing.T) {
+	tests := []struct {
+		name            string
+		markdown        string
+		wantOffsets     []int
+		wantContents    []string
+		wantBlockCount  int
+	}{
+		{
+			name: "single yaml block",
+			markdown: "# Title\n\nSome text.\n\n```yaml\njobs:\n  build:\n    steps:\n      - uses: actions/checkout@v4\n```\n",
+			wantBlockCount: 1,
+			wantOffsets:    []int{6},
+			wantContents:   []string{"jobs:\n  build:\n    steps:\n      - uses: actions/checkout@v4"},
+		},
+		{
+			name: "multiple blocks",
+			markdown: "```yaml\nfirst: block\n```\n\nSome prose.\n\n```yaml\nsecond: block\n```\n",
+			wantBlockCount: 2,
+			wantOffsets:    []int{2, 8},
+			wantContents:   []string{"first: block", "second: block"},
+		},
+		{
+			name:           "non-yaml fences are ignored",
+			markdown:       "```bash\necho hello\n```\n\n```go\nfmt.Println()\n```\n\n```yml\nruns: {}\n```\n",
+			wantBlockCount: 0,
+		},
+		{
+			name:           "unclosed fence is discarded",
+			markdown:       "```yaml\njobs: {}\n",
+			wantBlockCount: 0,
+		},
+		{
+			name:           "no code blocks",
+			markdown:       "# Just prose\n\nNo fences here.\n",
+			wantBlockCount: 0,
+		},
+		{
+			name: "case insensitive fence",
+			markdown: "```YAML\njobs: {}\n```\n",
+			wantBlockCount: 1,
+			wantOffsets:    []int{2},
+			wantContents:   []string{"jobs: {}"},
+		},
+		{
+			name: "fence with leading whitespace",
+			markdown: "  ```yaml\n  jobs: {}\n  ```\n",
+			wantBlockCount: 1,
+			wantOffsets:    []int{2},
+			wantContents:   []string{"  jobs: {}"},
+		},
+		{
+			name: "empty yaml block",
+			markdown: "```yaml\n```\n",
+			wantBlockCount: 1,
+			wantOffsets:    []int{2},
+			wantContents:   []string{""},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			blocks := extractYAMLBlocks([]byte(tt.markdown))
+			require.Len(t, blocks, tt.wantBlockCount)
+
+			for i, block := range blocks {
+				require.Equal(t, tt.wantOffsets[i], block.lineOffset, "block %d lineOffset", i)
+				require.Equal(t, tt.wantContents[i], string(block.content), "block %d content", i)
+			}
+		})
+	}
+}
+
+func TestExtractYAMLBlocksCRLF(t *testing.T) {
+	// CRLF line endings should be handled transparently.
+	markdown := "```yaml\r\njobs:\r\n  build:\r\n    steps:\r\n      - uses: actions/checkout@v4\r\n```\r\n"
+	blocks := extractYAMLBlocks([]byte(markdown))
+	require.Len(t, blocks, 1)
+	require.Equal(t, 2, blocks[0].lineOffset)
+	// \r should be stripped from content lines.
+	require.Equal(t, "jobs:\n  build:\n    steps:\n      - uses: actions/checkout@v4", string(blocks[0].content))
+}
+
+func TestFindActionRefsInMarkdownFile(t *testing.T) {
+	dir := t.TempDir()
+
+	// The uses: line is on markdown file line 7 (fence opens line 5, content
+	// starts line 6, uses: is the second content line → line 7).
+	markdown := "# README\n\nSome docs.\n\n```yaml\njobs:\n  build:\n    steps:\n      - uses: actions/checkout@v4\n```\n"
+	// Line numbers:        1          2              3       4           5       6       7       8       9                                10
+
+	path := filepath.Join(dir, "README.md")
+	require.NoError(t, os.WriteFile(path, []byte(markdown), 0o600))
+
+	actions, err := findActionRefsInMarkdownFile(path)
+	require.NoError(t, err)
+	require.Len(t, actions, 1)
+	require.Equal(t, "actions/checkout@v4", actions[0].Node.Value)
+	// Fence opens on line 5 → content starts line 6. uses: is YAML line 4 → file line 6+4-1 = 9.
+	require.Equal(t, 9, actions[0].Node.Line)
+}
+
+func TestFindActionRefsInMarkdownFileMultipleBlocks(t *testing.T) {
+	dir := t.TempDir()
+
+	markdown := "# Title\n\n```yaml\njobs:\n  a:\n    steps:\n      - uses: actions/checkout@v4\n```\n\nMore prose.\n\n```yaml\njobs:\n  b:\n    steps:\n      - uses: actions/setup-go@v5\n```\n"
+
+	path := filepath.Join(dir, "README.md")
+	require.NoError(t, os.WriteFile(path, []byte(markdown), 0o600))
+
+	actions, err := findActionRefsInMarkdownFile(path)
+	require.NoError(t, err)
+	require.Len(t, actions, 2)
+
+	values := []string{actions[0].Node.Value, actions[1].Node.Value}
+	require.Contains(t, values, "actions/checkout@v4")
+	require.Contains(t, values, "actions/setup-go@v5")
+}
+
+func TestFindActionRefsInMarkdownFileNoBlocks(t *testing.T) {
+	dir := t.TempDir()
+
+	path := filepath.Join(dir, "README.md")
+	require.NoError(t, os.WriteFile(path, []byte("# Just prose\n\nNo YAML here.\n"), 0o600))
+
+	actions, err := findActionRefsInMarkdownFile(path)
+	require.NoError(t, err)
+	require.Empty(t, actions)
+}
+
+func TestFindActionRefsInMarkdownFileMalformedYAML(t *testing.T) {
+	dir := t.TempDir()
+
+	// Malformed YAML inside a fence should not cause an error — it's skipped.
+	markdown := "```yaml\n: : : invalid\n```\n\n```yaml\njobs:\n  b:\n    steps:\n      - uses: actions/checkout@v4\n```\n"
+	path := filepath.Join(dir, "README.md")
+	require.NoError(t, os.WriteFile(path, []byte(markdown), 0o600))
+
+	actions, err := findActionRefsInMarkdownFile(path)
+	require.NoError(t, err)
+	require.Len(t, actions, 1)
+	require.Equal(t, "actions/checkout@v4", actions[0].Node.Value)
+}
+
+func TestFindMarkdownFiles(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+
+	writeFile(t, "README.md", "# root\n")
+	writeFile(t, "CONTRIBUTING.markdown", "# contrib\n")
+	writeFile(t, filepath.Join("docs", "guide.md"), "# guide\n")
+	writeFile(t, filepath.Join(".github", "PULL_REQUEST_TEMPLATE.md"), "# pr\n")
+	// Non-markdown files must be excluded.
+	writeFile(t, "workflow.yml", "jobs: {}\n")
+	writeFile(t, filepath.Join("docs", "notes.txt"), "ignored\n")
+	// Skipped directories must not appear.
+	writeFile(t, filepath.Join(".git", "COMMIT_EDITMSG"), "ignored\n")
+	writeFile(t, filepath.Join("node_modules", "pkg", "README.md"), "ignored\n")
+	writeFile(t, filepath.Join("vendor", "dep", "README.md"), "ignored\n")
+
+	files, err := findMarkdownFiles()
+	require.NoError(t, err)
+
+	require.ElementsMatch(t, []string{
+		"README.md",
+		"CONTRIBUTING.markdown",
+		filepath.Join("docs", "guide.md"),
+		filepath.Join(".github", "PULL_REQUEST_TEMPLATE.md"),
+	}, files)
+}

--- a/pkg/cmd/outdated.go
+++ b/pkg/cmd/outdated.go
@@ -10,13 +10,13 @@ import (
 
 // ListOutdatedActions prints every action that has a newer version available
 // and reports whether any were found.
-func ListOutdatedActions(ctx context.Context) (bool, error) {
+func ListOutdatedActions(ctx context.Context, opts CollectOptions) (bool, error) {
 	client, err := api.NewClient()
 	if err != nil {
 		return false, fmt.Errorf("create github client: %w", err)
 	}
 
-	_, refs, err := collectActionRefs()
+	_, refs, err := collectActionRefs(opts)
 	if err != nil {
 		return false, err
 	}

--- a/pkg/cmd/parse.go
+++ b/pkg/cmd/parse.go
@@ -101,10 +101,18 @@ func isYAMLFile(name string) bool {
 	return ext == ".yml" || ext == ".yaml"
 }
 
+// CollectOptions controls which sources are scanned for action references.
+type CollectOptions struct {
+	// IncludeMarkdown enables scanning of fenced YAML code blocks inside
+	// markdown files (*.md, *.markdown) in addition to workflow YAML files.
+	IncludeMarkdown bool
+}
+
 // collectActionRefs discovers every workflow/composite file and returns the
 // file list (in scan order) alongside the flat list of action references found
-// across them.
-func collectActionRefs() ([]string, []Action, error) {
+// across them. When opts.IncludeMarkdown is true, markdown files are also
+// scanned for fenced YAML blocks containing action references.
+func collectActionRefs(opts CollectOptions) ([]string, []Action, error) {
 	files, err := findWorkflowFiles()
 	if err != nil {
 		return nil, nil, fmt.Errorf("find workflow files: %w", err)
@@ -114,6 +122,34 @@ func collectActionRefs() ([]string, []Action, error) {
 
 	for _, filePath := range files {
 		found, err := findActionRefsInFile(filePath)
+		if err != nil {
+			return nil, nil, err
+		}
+
+		refs = append(refs, found...)
+	}
+
+	if !opts.IncludeMarkdown {
+		return files, refs, nil
+	}
+
+	mdFiles, err := findMarkdownFiles()
+	if err != nil {
+		return nil, nil, fmt.Errorf("find markdown files: %w", err)
+	}
+
+	seen := make(map[string]bool, len(files))
+	for _, f := range files {
+		seen[f] = true
+	}
+
+	for _, filePath := range mdFiles {
+		if !seen[filePath] {
+			seen[filePath] = true
+			files = append(files, filePath)
+		}
+
+		found, err := findActionRefsInMarkdownFile(filePath)
 		if err != nil {
 			return nil, nil, err
 		}

--- a/pkg/cmd/parse.go
+++ b/pkg/cmd/parse.go
@@ -138,17 +138,13 @@ func collectActionRefs(opts CollectOptions) ([]string, []Action, error) {
 		return nil, nil, fmt.Errorf("find markdown files: %w", err)
 	}
 
-	seen := make(map[string]bool, len(files))
-	for _, f := range files {
-		seen[f] = true
-	}
+	// Markdown files (*.md / *.markdown) can never appear in the workflow file
+	// list returned by findWorkflowFiles, which only collects *.yml / *.yaml
+	// and action.yml / action.yaml. There is therefore no risk of overlap and
+	// no deduplication is needed here.
+	files = append(files, mdFiles...)
 
 	for _, filePath := range mdFiles {
-		if !seen[filePath] {
-			seen[filePath] = true
-			files = append(files, filePath)
-		}
-
 		found, err := findActionRefsInMarkdownFile(filePath)
 		if err != nil {
 			return nil, nil, err

--- a/pkg/cmd/parse_test.go
+++ b/pkg/cmd/parse_test.go
@@ -154,6 +154,43 @@ func TestIsPinnableRef(t *testing.T) {
 	}
 }
 
+func TestCollectActionRefsWithMarkdown(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+
+	// A standard workflow YAML file with one action reference.
+	writeFile(t, filepath.Join(".github", "workflows", "ci.yml"), `
+jobs:
+  build:
+    steps:
+      - uses: actions/checkout@v4
+`)
+
+	// A markdown file whose fenced YAML block contains a second reference.
+	writeFile(t, "README.md", "# Example\n\n```yaml\njobs:\n  fmt:\n    uses: gdcorp-actions/setup-oxfmt/.github/workflows/oxfmt-check.yaml@v1.0.0\n```\n")
+
+	// With markdown disabled only the YAML ref should be found.
+	_, refs, err := collectActionRefs(CollectOptions{IncludeMarkdown: false})
+	require.NoError(t, err)
+	require.Len(t, refs, 1)
+	require.Equal(t, "actions/checkout@v4", refs[0].Node.Value)
+
+	// With markdown enabled both refs should be found.
+	files, refs, err := collectActionRefs(CollectOptions{IncludeMarkdown: true})
+	require.NoError(t, err)
+
+	values := make([]string, 0, len(refs))
+	for _, r := range refs {
+		values = append(values, r.Node.Value)
+	}
+
+	require.Contains(t, values, "actions/checkout@v4")
+	require.Contains(t, values, "gdcorp-actions/setup-oxfmt/.github/workflows/oxfmt-check.yaml@v1.0.0")
+
+	// The markdown file must appear in the returned file list.
+	require.Contains(t, files, "README.md")
+}
+
 func writeFile(t *testing.T, path, content string) {
 	t.Helper()
 

--- a/pkg/cmd/pin.go
+++ b/pkg/cmd/pin.go
@@ -4,6 +4,6 @@ import "context"
 
 // PinActions pins every action to the commit SHA of its currently resolved
 // version. When dryRun is true the changes are printed instead of written.
-func PinActions(ctx context.Context, dryRun bool) error {
-	return applyRewrite(ctx, modePin, dryRun)
+func PinActions(ctx context.Context, dryRun bool, opts CollectOptions) error {
+	return applyRewrite(ctx, modePin, dryRun, opts)
 }

--- a/pkg/cmd/rewrite.go
+++ b/pkg/cmd/rewrite.go
@@ -14,13 +14,13 @@ import (
 
 // applyRewrite resolves every action in the repository and rewrites each file
 // according to mode. It is shared by the pin and update commands.
-func applyRewrite(ctx context.Context, mode rewriteMode, dryRun bool) error {
+func applyRewrite(ctx context.Context, mode rewriteMode, dryRun bool, opts CollectOptions) error {
 	client, err := api.NewClient()
 	if err != nil {
 		return fmt.Errorf("create github client: %w", err)
 	}
 
-	files, refs, err := collectActionRefs()
+	files, refs, err := collectActionRefs(opts)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/update.go
+++ b/pkg/cmd/update.go
@@ -6,11 +6,11 @@ import "context"
 // each action is additionally pinned to a commit SHA, which is also required to
 // resolve branch references such as @main. When dryRun is true the changes are
 // printed instead of written.
-func UpdateActions(ctx context.Context, pin, dryRun bool) error {
+func UpdateActions(ctx context.Context, pin, dryRun bool, opts CollectOptions) error {
 	mode := modeUpdate
 	if pin {
 		mode = modeUpdatePin
 	}
 
-	return applyRewrite(ctx, mode, dryRun)
+	return applyRewrite(ctx, mode, dryRun, opts)
 }


### PR DESCRIPTION
## Summary

All four commands (`ls`, `outdated`, `update`, `pin`) now also process action references found inside ````yaml```` / ````yml```` fenced code blocks in markdown files (`*.md`, `*.markdown`). This lets READMEs that show usage examples stay in sync with the rest of the repository.

For example, a README containing:

```yaml
jobs:
  fmt:
    uses: my-org/my-action/.github/workflows/oxfmt-check.yaml@v1.0.0
```

will now be picked up and updated/pinned alongside workflow files.

Markdown scanning is **enabled by default**. Pass `--no-md` to any subcommand to opt out.

## Changes

- `pkg/cmd/markdown.go` — new file: `isMarkdownFile`, `extractYAMLBlocks`, `findMarkdownFiles`, `findActionRefsInMarkdownFile`
- `pkg/cmd/markdown_test.go` — new file: full test coverage for all new functions (fence detection, line offset calculation, CRLF handling, malformed YAML tolerance, file discovery)
- `pkg/cmd/parse.go` — `CollectOptions` struct; `collectActionRefs` accepts opts and wires in markdown discovery when `IncludeMarkdown` is true
- `pkg/cmd/rewrite.go`, `pin.go`, `update.go`, `outdated.go`, `list.go` — thread `CollectOptions` through to `collectActionRefs`
- `main.go` — `--no-md` flag on every subcommand

## How it works

1. After discovering workflow YAML files as before, `findMarkdownFiles()` walks the repo (skipping `.git`, `node_modules`, `vendor`) for `*.md`/`*.markdown` files.
2. `extractYAMLBlocks()` scans each file line-by-line for ````yaml````/````yml```` fences, capturing each block's content and its **line offset** within the markdown file.
3. Each block is parsed with the existing `parseActionRefs()`. The returned `Node.Line` values (relative to the YAML fragment) are adjusted by the offset so they point at the correct absolute line in the markdown file.
4. `rewriteFile()` is unchanged — it works purely on line numbers and the `uses:` string, so it handles markdown files transparently.