### PR TITLE
feat: add .mdx file support to markdown scanning

### DIFF
--- a/pkg/cmd/markdown.go
+++ b/pkg/cmd/markdown.go
@@ -14,7 +14,7 @@ import (
 func isMarkdownFile(name string) bool {
 	ext := strings.ToLower(filepath.Ext(name))
 
-	return ext == ".md" || ext == ".markdown"
+	return ext == ".md" || ext == ".markdown" || ext == ".mdx"
 }
 
 // yamlBlock is a YAML code fence extracted from a markdown file. lineOffset is

--- a/pkg/cmd/markdown_test.go
+++ b/pkg/cmd/markdown_test.go
@@ -20,7 +20,7 @@ func TestIsMarkdownFile(t *testing.T) {
 		{name: "workflow.yml", want: false},
 		{name: "action.yaml", want: false},
 		{name: "noextension", want: false},
-		{name: ".md", want: true},   // dotfile with .md extension
+		{name: ".md", want: true}, // dotfile with .md extension
 		{name: "file.mdx", want: true},
 		{name: "file.MDX", want: true},
 	}

--- a/pkg/cmd/markdown_test.go
+++ b/pkg/cmd/markdown_test.go
@@ -20,7 +20,9 @@ func TestIsMarkdownFile(t *testing.T) {
 		{name: "workflow.yml", want: false},
 		{name: "action.yaml", want: false},
 		{name: "noextension", want: false},
-		{name: ".md", want: true}, // dotfile with .md extension
+		{name: ".md", want: true},   // dotfile with .md extension
+		{name: "file.mdx", want: true},
+		{name: "file.MDX", want: true},
 	}
 
 	for _, tt := range tests {
@@ -209,6 +211,8 @@ func TestFindMarkdownFiles(t *testing.T) {
 	writeFile(t, "CONTRIBUTING.markdown", "# contrib\n")
 	writeFile(t, filepath.Join("docs", "guide.md"), "# guide\n")
 	writeFile(t, filepath.Join(".github", "PULL_REQUEST_TEMPLATE.md"), "# pr\n")
+	writeFile(t, "page.mdx", "# mdx page\n")
+	writeFile(t, filepath.Join("docs", "component.mdx"), "# mdx component\n")
 	// Non-markdown files must be excluded.
 	writeFile(t, "workflow.yml", "jobs: {}\n")
 	writeFile(t, filepath.Join("docs", "notes.txt"), "ignored\n")
@@ -225,5 +229,7 @@ func TestFindMarkdownFiles(t *testing.T) {
 		"CONTRIBUTING.markdown",
 		filepath.Join("docs", "guide.md"),
 		filepath.Join(".github", "PULL_REQUEST_TEMPLATE.md"),
+		"page.mdx",
+		filepath.Join("docs", "component.mdx"),
 	}, files)
 }


### PR DESCRIPTION
Extends the markdown file discovery to include `.mdx` files in addition to the existing `.md` and `.markdown` extensions.

## Changes

- `pkg/cmd/markdown.go`: Added `.mdx` to the `isMarkdownFile` extension check (case-insensitive).
- `pkg/cmd/markdown_test.go`: Extended `TestIsMarkdownFile` with `file.mdx` and `file.MDX` cases, and updated `TestFindMarkdownFiles` with two `.mdx` fixture files to verify they are discovered correctly.