### PR TITLE
Add --only flag to filter actions by owner/repo glob pattern

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,8 +96,12 @@ gh act update --pin --dry-run
 
 `ls`, `outdated`, `update` and `pin` all support `--only`, a repeatable flag
 that restricts the actions acted on to those matching a glob pattern of
-`owner/repo`. Matching is case-insensitive and happens before any GitHub API
-calls, which also helps on large repositories with many actions:
+`owner/repo`. An `owner/repo` pattern (no extra slashes) also matches
+subpath references such as reusable workflow calls
+(`owner/repo/.github/workflows/x.yml`); add more slashes to the pattern to
+target a subpath specifically. Matching is case-insensitive and happens
+before any GitHub API calls, which also helps on large repositories with
+many actions:
 
 ```sh
 gh act update --pin --only actions/setup-go --only golangci/golangci-lint-action

--- a/README.md
+++ b/README.md
@@ -92,6 +92,18 @@ gh act pin --dry-run
 gh act update --pin --dry-run
 ```
 
+#### Only update/pin specific actions
+
+`ls`, `outdated`, `update` and `pin` all support `--only`, a repeatable flag
+that restricts the actions acted on to those matching a glob pattern of
+`owner/repo`. Matching is case-insensitive and happens before any GitHub API
+calls, which also helps on large repositories with many actions:
+
+```sh
+gh act update --pin --only actions/setup-go --only golangci/golangci-lint-action
+gh act pin --only "actions/*"
+```
+
 #### Use in CI
 
 `outdated` exits `0` by default. Pass `--exit-code` to make it fail when any

--- a/main.go
+++ b/main.go
@@ -48,8 +48,16 @@ func run(ctx context.Context) error {
 		Usage: "Skip scanning fenced YAML code blocks in markdown files",
 	}
 
+	onlyFlag := &cli.StringSliceFlag{
+		Name:  "only",
+		Usage: "Only include actions matching these owner/repo glob patterns, repeatable (e.g. --only actions/* --only golangci/golangci-lint-action)",
+	}
+
 	collectOpts := func(c *cli.Command) cmd.CollectOptions {
-		return cmd.CollectOptions{IncludeMarkdown: !c.Bool("no-md")}
+		return cmd.CollectOptions{
+			IncludeMarkdown: !c.Bool("no-md"),
+			Filters:         c.StringSlice("only"),
+		}
 	}
 
 	command := &cli.Command{
@@ -72,7 +80,7 @@ func run(ctx context.Context) error {
 			{
 				Name:  "ls",
 				Usage: "List used actions",
-				Flags: []cli.Flag{noMDFlag},
+				Flags: []cli.Flag{noMDFlag, onlyFlag},
 				Action: func(_ context.Context, c *cli.Command) error {
 					return cmd.ListActions(collectOpts(c))
 				},
@@ -86,6 +94,7 @@ func run(ctx context.Context) error {
 						Usage: "Exit with a non-zero status when outdated actions are found",
 					},
 					noMDFlag,
+					onlyFlag,
 				},
 				Action: func(ctx context.Context, c *cli.Command) error {
 					found, err := cmd.ListOutdatedActions(ctx, collectOpts(c))
@@ -110,6 +119,7 @@ func run(ctx context.Context) error {
 					},
 					dryRunFlag,
 					noMDFlag,
+					onlyFlag,
 				},
 				Action: func(ctx context.Context, c *cli.Command) error {
 					return cmd.UpdateActions(ctx, c.Bool("pin"), c.Bool("dry-run"), collectOpts(c))
@@ -118,7 +128,7 @@ func run(ctx context.Context) error {
 			{
 				Name:  "pin",
 				Usage: "Pin used actions",
-				Flags: []cli.Flag{dryRunFlag, noMDFlag},
+				Flags: []cli.Flag{dryRunFlag, noMDFlag, onlyFlag},
 				Action: func(ctx context.Context, c *cli.Command) error {
 					return cmd.PinActions(ctx, c.Bool("dry-run"), collectOpts(c))
 				},

--- a/pkg/cmd/parse.go
+++ b/pkg/cmd/parse.go
@@ -184,18 +184,42 @@ func filterActionRefs(refs []Action, patterns []string) []Action {
 
 // matchesFilter reports whether an action reference's owner/repo(/subpath)
 // (the part of value before "@") matches any of the given glob patterns.
+// A pattern shaped like "owner/repo" (no more than one slash) is matched
+// against just the owner/repo of the reference, so it also matches
+// subpath references such as reusable workflow calls
+// (owner/repo/.github/workflows/x.yml). A pattern with additional slashes is
+// matched against the full reference, allowing more specific targeting.
 // Matching is case-insensitive; malformed patterns never match.
 func matchesFilter(value string, patterns []string) bool {
 	ref, _, _ := strings.Cut(value, "@")
 	ref = strings.ToLower(ref)
+	ownerRepo := firstTwoSegments(ref)
 
 	for _, pattern := range patterns {
-		if ok, err := path.Match(strings.ToLower(pattern), ref); err == nil && ok {
+		pattern = strings.ToLower(pattern)
+
+		target := ref
+		if strings.Count(pattern, "/") <= 1 {
+			target = ownerRepo
+		}
+
+		if ok, err := path.Match(pattern, target); err == nil && ok {
 			return true
 		}
 	}
 
 	return false
+}
+
+// firstTwoSegments returns the "owner/repo" portion of a slash-separated
+// reference, discarding any further subpath segments.
+func firstTwoSegments(ref string) string {
+	parts := strings.SplitN(ref, "/", 3)
+	if len(parts) < 2 {
+		return ref
+	}
+
+	return parts[0] + "/" + parts[1]
 }
 
 // findActionRefsInFile parses a single YAML file and returns the external

--- a/pkg/cmd/parse.go
+++ b/pkg/cmd/parse.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io/fs"
 	"os"
+	"path"
 	"path/filepath"
 	"strings"
 
@@ -106,12 +107,17 @@ type CollectOptions struct {
 	// IncludeMarkdown enables scanning of fenced YAML code blocks inside
 	// markdown files (*.md, *.markdown) in addition to workflow YAML files.
 	IncludeMarkdown bool
+	// Filters restricts collected references to those whose owner/repo(/subpath)
+	// matches one of these glob patterns (e.g. "actions/setup-go", "golangci/*").
+	// Matching is case-insensitive. An empty slice matches everything.
+	Filters []string
 }
 
 // collectActionRefs discovers every workflow/composite file and returns the
 // file list (in scan order) alongside the flat list of action references found
 // across them. When opts.IncludeMarkdown is true, markdown files are also
-// scanned for fenced YAML blocks containing action references.
+// scanned for fenced YAML blocks containing action references. When
+// opts.Filters is non-empty, only matching references are returned.
 func collectActionRefs(opts CollectOptions) ([]string, []Action, error) {
 	files, err := findWorkflowFiles()
 	if err != nil {
@@ -129,31 +135,67 @@ func collectActionRefs(opts CollectOptions) ([]string, []Action, error) {
 		refs = append(refs, found...)
 	}
 
-	if !opts.IncludeMarkdown {
-		return files, refs, nil
-	}
-
-	mdFiles, err := findMarkdownFiles()
-	if err != nil {
-		return nil, nil, fmt.Errorf("find markdown files: %w", err)
-	}
-
-	// Markdown files (*.md / *.markdown) can never appear in the workflow file
-	// list returned by findWorkflowFiles, which only collects *.yml / *.yaml
-	// and action.yml / action.yaml. There is therefore no risk of overlap and
-	// no deduplication is needed here.
-	files = append(files, mdFiles...)
-
-	for _, filePath := range mdFiles {
-		found, err := findActionRefsInMarkdownFile(filePath)
+	if opts.IncludeMarkdown {
+		mdFiles, err := findMarkdownFiles()
 		if err != nil {
-			return nil, nil, err
+			return nil, nil, fmt.Errorf("find markdown files: %w", err)
 		}
 
-		refs = append(refs, found...)
+		// Markdown files (*.md / *.markdown) can never appear in the workflow
+		// file list returned by findWorkflowFiles, which only collects
+		// *.yml / *.yaml and action.yml / action.yaml. There is therefore no
+		// risk of overlap and no deduplication is needed here.
+		files = append(files, mdFiles...)
+
+		for _, filePath := range mdFiles {
+			found, err := findActionRefsInMarkdownFile(filePath)
+			if err != nil {
+				return nil, nil, err
+			}
+
+			refs = append(refs, found...)
+		}
 	}
 
+	refs = filterActionRefs(refs, opts.Filters)
+
 	return files, refs, nil
+}
+
+// filterActionRefs returns only the refs whose owner/repo(/subpath) matches
+// one of the given glob patterns. An empty patterns slice returns refs
+// unchanged.
+func filterActionRefs(refs []Action, patterns []string) []Action {
+	if len(patterns) == 0 {
+		return refs
+	}
+
+	// Build a new slice; never mutate refs' backing array.
+	filtered := refs[:0:0]
+
+	for _, ref := range refs {
+		if matchesFilter(ref.Node.Value, patterns) {
+			filtered = append(filtered, ref)
+		}
+	}
+
+	return filtered
+}
+
+// matchesFilter reports whether an action reference's owner/repo(/subpath)
+// (the part of value before "@") matches any of the given glob patterns.
+// Matching is case-insensitive; malformed patterns never match.
+func matchesFilter(value string, patterns []string) bool {
+	ref, _, _ := strings.Cut(value, "@")
+	ref = strings.ToLower(ref)
+
+	for _, pattern := range patterns {
+		if ok, err := path.Match(strings.ToLower(pattern), ref); err == nil && ok {
+			return true
+		}
+	}
+
+	return false
 }
 
 // findActionRefsInFile parses a single YAML file and returns the external

--- a/pkg/cmd/parse_test.go
+++ b/pkg/cmd/parse_test.go
@@ -197,6 +197,8 @@ func TestCollectActionRefsWithFilter(t *testing.T) {
 
 	writeFile(t, filepath.Join(".github", "workflows", "ci.yml"), `
 jobs:
+  call:
+    uses: octo-org/repo/.github/workflows/release.yml@v1
   build:
     steps:
       - uses: actions/checkout@v4
@@ -210,14 +212,34 @@ jobs:
 		expected []string
 	}{
 		{
-			name:     "no filter returns everything",
-			filters:  nil,
-			expected: []string{"actions/checkout@v4", "actions/setup-go@v5", "golangci/golangci-lint-action@v6"},
+			name:    "no filter returns everything",
+			filters: nil,
+			expected: []string{
+				"octo-org/repo/.github/workflows/release.yml@v1",
+				"actions/checkout@v4",
+				"actions/setup-go@v5",
+				"golangci/golangci-lint-action@v6",
+			},
 		},
 		{
 			name:     "exact match",
 			filters:  []string{"actions/setup-go"},
 			expected: []string{"actions/setup-go@v5"},
+		},
+		{
+			name:     "owner/repo pattern matches subpath reference",
+			filters:  []string{"octo-org/repo"},
+			expected: []string{"octo-org/repo/.github/workflows/release.yml@v1"},
+		},
+		{
+			name:     "pattern with extra slashes targets the subpath specifically",
+			filters:  []string{"octo-org/repo/.github/workflows/*"},
+			expected: []string{"octo-org/repo/.github/workflows/release.yml@v1"},
+		},
+		{
+			name:     "pattern with extra slashes excludes non-matching subpath",
+			filters:  []string{"octo-org/repo/.github/workflows/other.yml"},
+			expected: []string{},
 		},
 		{
 			name:     "glob match",

--- a/pkg/cmd/parse_test.go
+++ b/pkg/cmd/parse_test.go
@@ -191,6 +191,71 @@ jobs:
 	require.Contains(t, files, "README.md")
 }
 
+func TestCollectActionRefsWithFilter(t *testing.T) {
+	dir := t.TempDir()
+	t.Chdir(dir)
+
+	writeFile(t, filepath.Join(".github", "workflows", "ci.yml"), `
+jobs:
+  build:
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+      - uses: golangci/golangci-lint-action@v6
+`)
+
+	tests := []struct {
+		name     string
+		filters  []string
+		expected []string
+	}{
+		{
+			name:     "no filter returns everything",
+			filters:  nil,
+			expected: []string{"actions/checkout@v4", "actions/setup-go@v5", "golangci/golangci-lint-action@v6"},
+		},
+		{
+			name:     "exact match",
+			filters:  []string{"actions/setup-go"},
+			expected: []string{"actions/setup-go@v5"},
+		},
+		{
+			name:     "glob match",
+			filters:  []string{"actions/*"},
+			expected: []string{"actions/checkout@v4", "actions/setup-go@v5"},
+		},
+		{
+			name:     "multiple filters",
+			filters:  []string{"actions/setup-go", "golangci/golangci-lint-action"},
+			expected: []string{"actions/setup-go@v5", "golangci/golangci-lint-action@v6"},
+		},
+		{
+			name:     "case-insensitive",
+			filters:  []string{"ACTIONS/SETUP-GO"},
+			expected: []string{"actions/setup-go@v5"},
+		},
+		{
+			name:     "no match returns nothing",
+			filters:  []string{"octo/nonexistent"},
+			expected: []string{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, refs, err := collectActionRefs(CollectOptions{Filters: tt.filters})
+			require.NoError(t, err)
+
+			values := make([]string, 0, len(refs))
+			for _, ref := range refs {
+				values = append(values, ref.Node.Value)
+			}
+
+			require.Equal(t, tt.expected, values)
+		})
+	}
+}
+
 func writeFile(t *testing.T, path, content string) {
 	t.Helper()
 


### PR DESCRIPTION
## Summary

Adds a repeatable `--only` flag to `ls`, `outdated`, `update` and `pin` to restrict which actions are acted on, useful for large repositories where you only want to touch a handful of actions.

```sh
gh act update --pin --only actions/setup-go --only golangci/golangci-lint-action
gh act pin --only "actions/*"
```

## Details

- `CollectOptions.Filters []string` added; filtering happens in `collectActionRefs` before any GitHub API calls, so it also cuts down on unnecessary requests for large repos.
- Matching uses stdlib `path.Match` against the `owner/repo(/subpath)` portion of the reference (before `@`), case-insensitive. Supports glob patterns (`*`, `?`, `[...]`); an empty filter list matches everything (no behavior change by default).
- Wired into `main.go` as a `cli.StringSliceFlag` shared across all four commands.

## Testing

- New table-driven test `TestCollectActionRefsWithFilter` covering no filter, exact match, glob match, multiple filters, case-insensitivity, and no-match.
- `go build ./...`, `go vet ./...`, `go test ./...`, and `golangci-lint run ./...` all pass.
- Manually verified `gh act ls --only actions/setup-go --only golangci/golangci-lint-action` against a temp workflow file.